### PR TITLE
Add anonymous login option

### DIFF
--- a/components/Login.tsx
+++ b/components/Login.tsx
@@ -9,7 +9,7 @@ interface LoginProps {
 export const Login: React.FC<LoginProps> = ({ onToggleForm, onForgotPassword }) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const { login, error, loading } = useAuth();
+  const { login, loginAnonymously, error, loading } = useAuth();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -89,7 +89,7 @@ export const Login: React.FC<LoginProps> = ({ onToggleForm, onForgotPassword }) 
         </div>
       </form>
 
-      <div className="mt-6 text-center">
+      <div className="mt-6 text-center space-y-2">
         <p className="text-sm text-gray-600">
           Não tem uma conta?{' '}
           <button
@@ -99,6 +99,14 @@ export const Login: React.FC<LoginProps> = ({ onToggleForm, onForgotPassword }) 
             Cadastre-se
           </button>
         </p>
+        <button
+          type="button"
+          disabled={loading}
+          onClick={loginAnonymously}
+          className="text-sm text-gray-500 hover:text-gray-700 focus:outline-none"
+        >
+          Acessar como visitante
+        </button>
       </div>
     </div>
   );

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -14,6 +14,7 @@ interface AuthContextType {
   user: User | null;
   loading: boolean;
   login: (email: string, password: string) => Promise<boolean>;
+  loginAnonymously: () => Promise<boolean>;
   register: (name: string, email: string, password: string) => Promise<boolean>;
   logout: () => void;
   resetPassword: (email: string) => Promise<boolean>;
@@ -92,6 +93,27 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     } catch (err: any) {
       console.error('Erro durante o login:', err);
       setError(typeof err === 'string' ? err : (err.message || 'Erro desconhecido ao fazer login'));
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loginAnonymously = async (): Promise<boolean> => {
+    setError(null);
+    try {
+      setLoading(true);
+      const response = await firebaseAuthService.loginAnonymously();
+      if (response.success) {
+        setUser(response.user);
+        return true;
+      } else {
+        setError(response.error || 'Erro ao entrar como anônimo');
+        return false;
+      }
+    } catch (err: any) {
+      console.error('Erro durante login anônimo:', err);
+      setError(typeof err === 'string' ? err : err.message || 'Erro desconhecido ao entrar como anônimo');
       return false;
     } finally {
       setLoading(false);
@@ -242,7 +264,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   };
 
   return (
-    <AuthContext.Provider value={{ user, loading, login, register, logout, resetPassword, updatePassword, error }}>
+    <AuthContext.Provider value={{ user, loading, login, loginAnonymously, register, logout, resetPassword, updatePassword, error }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- support anonymous auth in Firebase auth service
- expose anonymous login in AuthContext
- add "Acessar como visitante" option to login screen

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683fa50d1f8c8325b1844011d0d6ff51